### PR TITLE
Fix #28 - Remove unnecessary require statement

### DIFF
--- a/js/clip-path-polygon.js
+++ b/js/clip-path-polygon.js
@@ -8,7 +8,7 @@
  */
 
 var globalVariable = window || root;
-var jQuery = jQuery || globalVariable.jQuery || (require && require('jquery'));
+var jQuery = jQuery || globalVariable.jQuery || require("jquery");
 
 (function($) {
   var id = 0;

--- a/js/clip-path-polygon.js
+++ b/js/clip-path-polygon.js
@@ -8,7 +8,7 @@
  */
 
 var globalVariable = window || root;
-var jQuery = jQuery || globalVariable.jQuery;
+var jQuery = jQuery || globalVariable.jQuery || (require && require('jquery'));
 
 (function($) {
   var id = 0;

--- a/js/clip-path-polygon.js
+++ b/js/clip-path-polygon.js
@@ -8,7 +8,7 @@
  */
 
 var globalVariable = window || root;
-var jQuery = jQuery || globalVariable.jQuery || (require && require('jquery'));
+var jQuery = jQuery || globalVariable.jQuery;
 
 (function($) {
   var id = 0;


### PR DESCRIPTION
Without the first `require`  in `(require && require('jquery'));`, webpack doesn't throw a warning anymore and compiles the [webpack test project](https://github.com/manniL/webpack-polyong-test-project) correctly.

This should fix #28